### PR TITLE
Fix date parsing

### DIFF
--- a/lib/ex_ical/date_parser.ex
+++ b/lib/ex_ical/date_parser.ex
@@ -3,14 +3,16 @@ defmodule ExIcal.DateParser do
 
   def parse(data), do: parse(data, nil)
 
+  def parse(data, timezone) when is_nil(timezone), do: parse(data, :utc)
+
   def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2), "T",
-                        hour :: binary-size(2), minutes :: binary-size(2), seconds :: binary-size(2), "Z" >>, nil) do
+                        hour :: binary-size(2), minutes :: binary-size(2), seconds :: binary-size(2), "Z" >>, timezone) do
       %DateTime{year: year |> String.to_integer, month: month |> String.to_integer, day: day |> String.to_integer,
-                hour: hour |> String.to_integer, minute: minutes |> String.to_integer, second: seconds |> String.to_integer, timezone: Timezone.get(:utc)}
+                hour: hour |> String.to_integer, minute: minutes |> String.to_integer, second: seconds |> String.to_integer, timezone: Timezone.get(timezone)}
   end
 
-  def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2), "Z" >>, nil) do
-      %DateTime{year: year |> String.to_integer, month: month |> String.to_integer, day: day |> String.to_integer, timezone: Timezone.get(:utc)}
+  def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2), "Z" >>, timezone) do
+      %DateTime{year: year |> String.to_integer, month: month |> String.to_integer, day: day |> String.to_integer, timezone: Timezone.get(timezone)}
   end
 
   def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2), "T",

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule ExIcal.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: []]
+    [applications: [:timex]]
   end
 
   defp deps do

--- a/test/ex_ical_date_parser_test.exs
+++ b/test/ex_ical_date_parser_test.exs
@@ -1,0 +1,40 @@
+defmodule ExIcalDateParserTest do
+  use ExUnit.Case
+  use Timex
+
+  alias ExIcal.DateParser
+
+  doctest ExIcal
+
+  test "parse date time (+zone) without timezone" do
+    assert Timex.Date.equal?(DateParser.parse("20160518T140530Z"), Timex.Date.from({{2016, 5, 18}, {14, 5, 30}}, :utc))
+  end
+
+  test "parse date time (+zone) with timezone" do
+    assert Timex.Date.equal?(DateParser.parse("20160518T140530Z", "Europe/Berlin"), Timex.Date.from({{2016, 5, 18}, {14, 5, 30}}, "Europe/Berlin"))
+  end
+
+  test "parse date without (+zone) timezone" do
+    assert Timex.Date.equal?(DateParser.parse("20160518Z"), Timex.Date.from({2016, 5, 18}, :utc))
+  end
+
+  test "parse date with (+zone) timezone" do
+    assert Timex.Date.equal?(DateParser.parse("20160518Z", "Europe/Berlin"), Timex.Date.from({2016, 5, 18}, "Europe/Berlin"))
+  end
+
+  test "parse date time without timezone" do
+    assert Timex.Date.equal?(DateParser.parse("20160518T140530"), Timex.Date.from({{2016, 5, 18}, {14, 5, 30}}, :utc))
+  end
+
+  test "parse date time with timezone" do
+    assert Timex.Date.equal?(DateParser.parse("20160518T140530", "Europe/Berlin"), Timex.Date.from({{2016, 5, 18}, {14, 5, 30}}, "Europe/Berlin"))
+  end
+
+  test "parse date without timezone" do
+    assert Timex.Date.equal?(DateParser.parse("20160518"), Timex.Date.from({2016, 5, 18}, :utc))
+  end
+
+  test "parse date with timezone" do
+    assert Timex.Date.equal?(DateParser.parse("20160518", "Europe/Berlin"), Timex.Date.from({2016, 5, 18}, "Europe/Berlin"))
+  end
+end


### PR DESCRIPTION
Fix dependencies in `mix.exs`.
Date parsing with `NULL` timezone values are fixed.
Add tests for date parser.
