### PR TITLE
Fix DateParser date/timezone formats

### DIFF
--- a/lib/ex_ical/date_parser.ex
+++ b/lib/ex_ical/date_parser.ex
@@ -3,23 +3,71 @@ defmodule ExIcal.DateParser do
 
   def parse(data), do: parse(data, nil)
 
+  # Date Format: "19690620T201804Z", Timezone: nil
   def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2), "T",
-                        hour :: binary-size(2), minutes :: binary-size(2), seconds :: binary-size(2), "Z" >>, nil) do
-      %DateTime{year: year |> String.to_integer, month: month |> String.to_integer, day: day |> String.to_integer,
-                hour: hour |> String.to_integer, minute: minutes |> String.to_integer, second: seconds |> String.to_integer, timezone: Timezone.get(:utc)}
+               hour :: binary-size(2), minutes :: binary-size(2), seconds :: binary-size(2), "Z" >>,
+               nil) do
+    {date, time} = {{year, month, day}, {hour, minutes, seconds}}
+    datetime_from_params(date, time)
   end
 
+  # Date Format: "19690620Z", Timezone: nil
   def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2), "Z" >>, nil) do
-      %DateTime{year: year |> String.to_integer, month: month |> String.to_integer, day: day |> String.to_integer, timezone: Timezone.get(:utc)}
+    {date, time} = {{year, month, day}, {}}
+    datetime_from_params(date, time)
   end
 
+  # Date Format: "19690620", Timezone: nil
+  def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2) >>, nil) do
+    {date, time} = {{year, month, day}, {}}
+    datetime_from_params(date, time)
+  end
+
+  # Date Format: "19690620T201804Z", Timezone: *
   def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2), "T",
-                        hour :: binary-size(2), minutes :: binary-size(2), seconds :: binary-size(2) >>, timezone) do
-      %DateTime{year: year |> String.to_integer, month: month |> String.to_integer, day: day |> String.to_integer,
-                hour: hour |> String.to_integer, minute: minutes |> String.to_integer, second: seconds |> String.to_integer, timezone: Timezone.get(timezone)}
+               hour :: binary-size(2), minutes :: binary-size(2), seconds :: binary-size(2), "Z" >>,
+               timezone) do
+    {date, time} = {{year, month, day}, {hour, minutes, seconds}}
+    datetime_from_params(date, time, timezone)
   end
 
+  # Date Format: "19690620Z", Timezone: *
+  def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2), "Z" >>, timezone) do
+    {date, time} = {{year, month, day}, {}}
+    datetime_from_params(date, time, timezone)
+  end
+
+  # Date Format: "19690620", Timezone: *
   def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2) >>, timezone) do
-      %DateTime{year: year |> String.to_integer, month: month |> String.to_integer, day: day |> String.to_integer, timezone: Timezone.get(timezone)}
+    {date, time} = {{year, month, day}, {}}
+    datetime_from_params(date, time, timezone)
+  end
+
+  # Takes a date, time, and timezone and returns a %Timex.DateTime{}.
+  #
+  # Date is required and must be a tuple in the format {year, month, day}.
+  # Time may be en empty tuple, but to be included, it must be in the format
+  # {hour, minute, second}. Timezone is also optional and defaults to :utc.
+
+  @spec datetime_from_params(tuple, tuple, any) :: %Timex.DateTime{}
+  defp datetime_from_params(date, time, timezone \\ :utc)
+  defp datetime_from_params({year, month, day}, {hour, minute, second}, timezone) do
+    %DateTime{
+      year: year   |> String.to_integer,
+      month: month |> String.to_integer,
+      day: day     |> String.to_integer,
+      hour: hour     |> String.to_integer,
+      minute: minute |> String.to_integer,
+      second: second |> String.to_integer,
+      timezone: Timezone.get(timezone)
+    }
+  end
+  defp datetime_from_params({year, month, day}, {}, timezone) do
+    %DateTime{
+      year:     year  |> String.to_integer,
+      month:    month |> String.to_integer,
+      day:      day   |> String.to_integer,
+      timezone: Timezone.get(timezone)
+    }
   end
 end

--- a/lib/ex_ical/parser.ex
+++ b/lib/ex_ical/parser.ex
@@ -3,9 +3,12 @@ defmodule ExIcal.Parser do
   alias ExIcal.Event
 
   def parse(data) do
-    data |> String.split("\n") |> Enum.reduce(%{events: []}, fn(line, data) ->
+    data
+    |> String.split("\n")
+    |> Enum.reduce(%{events: []}, fn(line, data) ->
       parse_line(String.strip(line), data)
-    end) |> Map.get(:events)
+    end)
+    |> Map.get(:events)
   end
 
   defp parse_line("BEGIN:VEVENT" <> _, data),           do: %{events: [%Event{}] ++ data[:events]}
@@ -19,9 +22,9 @@ defmodule ExIcal.Parser do
   defp parse_line(_, data), do: data
 
   defp put_to_map(%{events: events} = data, key, value) when length(events) > 0 do
-    [ event | other ] = events
-    event = %{ event | key => value}
-    %{ data | events: [event] ++ other }
+    [event | other] = events
+    event = %{event | key => value}
+    %{data | events: [event] ++ other}
   end
   defp put_to_map(data, _key, _value), do: data
 
@@ -39,11 +42,11 @@ defmodule ExIcal.Parser do
     rrule |> String.split(";") |> Enum.reduce(%{}, fn(rule, hash) ->
       [key, value] = rule |> String.split("=")
       case key |> String.downcase |> String.to_atom do
-        :until -> hash |> Map.put(:until, DateParser.parse(value, tzid))
+        :until    -> hash |> Map.put(:until, DateParser.parse(value, tzid))
         :interval -> hash |> Map.put(:interval, String.to_integer(value))
-        :count -> hash |> Map.put(:count, String.to_integer(value))
-        :freq -> hash |> Map.put(:freq, value)
-        _ -> hash
+        :count    -> hash |> Map.put(:count, String.to_integer(value))
+        :freq     -> hash |> Map.put(:freq, value)
+        _         -> hash
       end
     end)
   end

--- a/test/date_parser_input_format_test.exs
+++ b/test/date_parser_input_format_test.exs
@@ -1,0 +1,34 @@
+defmodule DateParserInputFormatTest do
+  use ExUnit.Case
+  use Timex
+
+  alias ExIcal.DateParser
+
+  doctest DateParser
+
+  allowed_date_formats = [
+    "19690620",
+    "19690620Z",
+    "19690620T201804Z",
+  ]
+
+  allowed_date_formats |> Enum.each(fn(date) ->
+    test "DateParser.parse/1 (date format: #{date})" do
+      parsed_date = DateParser.parse unquote(date)
+      assert %{year: 1969, month: 6, day: 20,
+               timezone: %{abbreviation: "UTC"}} = parsed_date
+    end
+
+    test "DateParser.parse/2 (timezone: nil, date format: #{date})" do
+      parsed_date = DateParser.parse(unquote(date), nil)
+      assert %{year: 1969, month: 6, day: 20,
+               timezone: %{abbreviation: "UTC"}} = parsed_date
+    end
+
+    test "DateParser.parse/2 (timezone: :utc, date format: #{date})" do
+      parsed_date = DateParser.parse(unquote(date), :utc)
+      assert %{year: 1969, month: 6, day: 20,
+               timezone: %{abbreviation: "UTC"}} = parsed_date
+    end
+  end)
+end


### PR DESCRIPTION
This pull request resolves issue #2 (including relevant tests for DateParser).
- **fix**: add pattern for the "19690629" format with no timezone
- **fix**: add pattern for the "19690629T201804Z" format with timezone
- **tests**: add DateParser input format tests to verify that the desired date formats are parsed correctly
- **refactor**: extract private function `datetime_from_params/3` to reduce code duplication
- **style**: standardize whitespace/bracket spacing in `ExIcal.Parser` (no space around brackets)
- **style**: break a long pipe-forward chain into multiple lines for easier reading

The goal of this PR is to add test coverage over the currently broken DateParser parsing cases and then to add coverage for those cases.

In order to make sure that each possible date format paired with each possible timezone input was valid, the tests are written in a loop.

To make adding patterns easier, I extracted the `%DateTime{}` creation logic out into a private method. Now, the relevant tuples (date, time) are constructed with pattern matching and passed to `datetime_from_params/3`. Hopefully this will make future changes easier.
