### PR TITLE
Desc multiline

### DIFF
--- a/test/ex_ical_daily_test.exs
+++ b/test/ex_ical_daily_test.exs
@@ -6,17 +6,17 @@ defmodule ExIcalDailyTest do
 
   test "daily reccuring event with until" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=DAILY;UNTIL=20151231T083000Z
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=DAILY;UNTIL=20151231T083000Z
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 8
@@ -41,17 +41,17 @@ defmodule ExIcalDailyTest do
 
   test "daily reccuring event" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=DAILY
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=DAILY
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20151230T084500Z"))
     assert events |> Enum.count == 7
@@ -74,17 +74,17 @@ defmodule ExIcalDailyTest do
 
   test "daily reccuring event with until and interval" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=DAILY;UNTIL=20151231T083000Z;INTERVAL=3
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=DAILY;UNTIL=20151231T083000Z;INTERVAL=3
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 3
@@ -99,17 +99,17 @@ defmodule ExIcalDailyTest do
 
   test "daily reccuring event with count" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=DAILY;COUNT=5
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=DAILY;COUNT=5
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 6
@@ -130,17 +130,17 @@ defmodule ExIcalDailyTest do
 
   test "daily reccuring event with count and interval" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=DAILY;COUNT=5;INTERVAL=2
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=DAILY;COUNT=5;INTERVAL=2
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 6
@@ -161,17 +161,17 @@ defmodule ExIcalDailyTest do
 
   test "daily reccuring event with interval" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=DAILY;INTERVAL=2
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=DAILY;INTERVAL=2
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20151231T084500Z"))
     assert events |> Enum.count == 4

--- a/test/ex_ical_monthly_test.exs
+++ b/test/ex_ical_monthly_test.exs
@@ -6,17 +6,17 @@ defmodule ExIcalMonthlyTest do
 
   test "monthly reccuring event with until" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=MONTHLY;UNTIL=20161224T083000Z
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=MONTHLY;UNTIL=20161224T083000Z
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 13
@@ -51,17 +51,17 @@ defmodule ExIcalMonthlyTest do
 
   test "monthly reccuring event" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=MONTHLY
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=MONTHLY
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20160924T084500Z"))
     assert events |> Enum.count == 10
@@ -90,17 +90,17 @@ defmodule ExIcalMonthlyTest do
 
   test "monthly reccuring event with until and interval" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=MONTHLY;UNTIL=20161224T083000Z;INTERVAL=3
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=MONTHLY;UNTIL=20161224T083000Z;INTERVAL=3
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 5
@@ -119,17 +119,17 @@ defmodule ExIcalMonthlyTest do
 
   test "monthly reccuring event with count" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=MONTHLY;COUNT=5
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=MONTHLY;COUNT=5
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 6
@@ -150,17 +150,17 @@ defmodule ExIcalMonthlyTest do
 
   test "monthly reccuring event with count and interval" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=MONTHLY;COUNT=5;INTERVAL=2
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=MONTHLY;COUNT=5;INTERVAL=2
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 6
@@ -181,17 +181,17 @@ defmodule ExIcalMonthlyTest do
 
   test "monthly reccuring event with interval" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=MONTHLY;INTERVAL=2
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=MONTHLY;INTERVAL=2
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 7

--- a/test/ex_ical_test.exs
+++ b/test/ex_ical_test.exs
@@ -10,17 +10,17 @@ defmodule ExIcalTest do
 
   test "event" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      CATEGORIES:MOVIES,SOCIAL
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    CATEGORIES:MOVIES,SOCIAL
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical)
 
@@ -33,5 +33,74 @@ defmodule ExIcalTest do
     assert event.start == DateParser.parse("20151224T083000Z")
     assert event.end == DateParser.parse("20151224T084500Z")
     assert event.categories == ["MOVIES", "SOCIAL"]
+  end
+
+  test "event with escaped characters" do
+    ical = """
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    DESCRIPTION:Let's go\, see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
+    """
+    events = ExIcal.parse(ical)
+
+    assert events |> Enum.count == 1
+
+    event = events |> List.first
+
+    assert event.description == "Let's go, see Star Wars."
+  end
+
+  test "event with multiline description" do
+    ical = """
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    DESCRIPTION:Let's go!\n\tWanna see Star Wars?\n\x20It's great
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
+    """
+    events = ExIcal.parse(ical)
+
+    assert events |> Enum.count == 1
+
+    event = events |> List.first
+
+    assert event.description == "Let's go!\nWanna see Star Wars?\nIt's great"
+  end
+
+  test "event with spaces around" do
+    ical = """
+       BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    DESCRIPTION:Let's go!\n\tWanna see Star Wars?\n\x20It's great
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
+    """
+    events = ExIcal.parse(ical)
+
+    assert events |> Enum.count == 1
+
+    event = events |> List.first
+
+    assert event.description == "Let's go!\nWanna see Star Wars?\nIt's great"
+    assert event.summary == "Film with Amy and Adam"
+    assert event.start == DateParser.parse("20151224T083000Z")
+    assert event.end == DateParser.parse("20151224T084500Z")
   end
 end

--- a/test/ex_ical_tzid_test.exs
+++ b/test/ex_ical_tzid_test.exs
@@ -5,18 +5,18 @@ defmodule ExIcalTzidTest do
   test "daily reccuring event with until and tzid" do
     tzid = "Europe/Berlin"
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      TZID:#{tzid}
-      BEGIN:VEVENT
-      RRULE:FREQ=DAILY;UNTIL=20151231T083000
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500
-      DTSTART:20151224T083000
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    TZID:#{tzid}
+    BEGIN:VEVENT
+    RRULE:FREQ=DAILY;UNTIL=20151231T083000
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500
+    DTSTART:20151224T083000
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ical
              |> ExIcal.parse

--- a/test/ex_ical_weekly_test.exs
+++ b/test/ex_ical_weekly_test.exs
@@ -6,17 +6,17 @@ defmodule ExIcalWeeklyTest do
 
   test "weekly reccuring event with until" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=WEEKLY;UNTIL=20160201T083000Z
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=WEEKLY;UNTIL=20160201T083000Z
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 6
@@ -37,17 +37,17 @@ defmodule ExIcalWeeklyTest do
 
   test "weekly reccuring event" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=WEEKLY
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=WEEKLY
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20160121T084500Z"))
     assert events |> Enum.count == 5
@@ -66,17 +66,17 @@ defmodule ExIcalWeeklyTest do
 
   test "weekly reccuring event with until and interval" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=WEEKLY;UNTIL=20161224T083000Z;INTERVAL=8
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=WEEKLY;UNTIL=20161224T083000Z;INTERVAL=8
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 7
@@ -100,17 +100,17 @@ defmodule ExIcalWeeklyTest do
 
   test "weekly reccuring event with count" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=WEEKLY;COUNT=5
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=WEEKLY;COUNT=5
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 6
@@ -131,17 +131,17 @@ defmodule ExIcalWeeklyTest do
 
   test "weekly reccuring event with count and interval" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=WEEKLY;COUNT=4;INTERVAL=8
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=WEEKLY;COUNT=4;INTERVAL=8
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 5
@@ -160,17 +160,17 @@ defmodule ExIcalWeeklyTest do
 
   test "weekly reccuring event with interval" do
     ical = """
-      BEGIN:VCALENDAR
-      CALSCALE:GREGORIAN
-      VERSION:2.0
-      BEGIN:VEVENT
-      RRULE:FREQ=WEEKLY;INTERVAL=8
-      DESCRIPTION:Let's go see Star Wars.
-      DTEND:20151224T084500Z
-      DTSTART:20151224T083000Z
-      SUMMARY:Film with Amy and Adam
-      END:VEVENT
-      END:VCALENDAR
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    RRULE:FREQ=WEEKLY;INTERVAL=8
+    DESCRIPTION:Let's go see Star Wars.
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
     """
     events = ExIcal.parse(ical) |> ExIcal.by_range(DateParser.parse("20151224T083000Z"), DateParser.parse("20161224T084500Z"))
     assert events |> Enum.count == 7


### PR DESCRIPTION
Property values in iCalendar can be on multiple lines if unfolding is used (https://tools.ietf.org/html/rfc5545#section-3.1)

Bases also on #12