### PR TITLE
Fix timezone parser issue and deprecation warning

### DIFF
--- a/lib/ex_ical/parser.ex
+++ b/lib/ex_ical/parser.ex
@@ -36,9 +36,12 @@ defmodule ExIcal.Parser do
     data
     |> String.replace(~s"\n\t", ~S"\n")
     |> String.replace(~s"\n\x20", ~S"\n")
+    |> String.replace(~s"\"", "")
     |> String.split("\n")
     |> Enum.reduce(%{events: []}, fn(line, data) ->
-      parse_line(String.strip(line), data)
+      line
+      |> String.trim() 
+      |> parse_line(data)
     end)
     |> Map.get(:events)
   end


### PR DESCRIPTION
Fix bug in timezone parser: in case string like "TZID=\"Europe/Moscow\":20190301T080000" result will {:error, {:invalid_timezone, "\"Europe/Moscow\""}}. Also fix deprecation warning: 
`warning: String.strip/1 is deprecated. Use String.trim/1 instead
  lib/ex_ical/parser.ex:42`