### PR TITLE
Skip parsing of the VTIMEZONE entries

### DIFF
--- a/lib/ex_ical/parser.ex
+++ b/lib/ex_ical/parser.ex
@@ -38,10 +38,12 @@ defmodule ExIcal.Parser do
     |> String.replace(~s"\n\x20", ~S"\n")
     |> String.replace(~s"\"", "")
     |> String.split("\n")
-    |> Enum.reduce(%{events: []}, fn(line, data) ->
-      line
-      |> String.trim() 
-      |> parse_line(data)
+    |> Enum.reduce_while(%{events: []}, fn(line, data) ->
+      line = String.trim(line)
+      case String.starts_with?(line, "BEGIN:VTIMEZONE") do
+        true -> {:halt, data}
+        false -> {:cont, parse_line(line, data)}
+      end
     end)
     |> Map.get(:events)
   end


### PR DESCRIPTION
Hi @fazibear 

I noticed that the current implementation of the `parse` function and its helper `put_to_map` modify the **starting date** of the newest event due to the processing of **VTIMEZONE** entries.

For example, the **start date** of last event (_Test #5_) of this log is **2019-10-25**, however as `put_to_map` always update the latest event, and the **VTIMEZONE** entry also have a **DTSTART** field the event will get the value of  the last **DTSTART** of the **VTIMEZONE* entry, in this example **1996-10-27**

This pull request skip the processing the processing of **VTIMEZONE** entries so the start date of the last event is not modified.

Note: I'm using the Apple Calendar
.....
_"BEGIN:VEVENT"_
"CREATED:20191025T115913Z"
"UID:866BE96C-3A70-4F7A-9A72-EF496C2DD7CF"
"DTEND;TZID=Europe/Brussels:20191025T163000"
"TRANSP:OPAQUE"
"X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC"
**_"SUMMARY:Test #5"_**
"LAST-MODIFIED:20191025T115933Z"
"DTSTAMP:20191025T115933Z"
**"DTSTART;TZID=Europe/Brussels:20191025T151500"**
"SEQUENCE:0"
_"END:VEVENT"_
_"BEGIN:VTIMEZONE"_
"TZID:Europe/Brussels"
"BEGIN:DAYLIGHT"
"TZOFFSETFROM:+0100"
"RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU"
**"DTSTART:19810329T020000"**
"TZNAME:GMT+02:00"
"TZOFFSETTO:+0200"
"END:DAYLIGHT"
"BEGIN:STANDARD"
"TZOFFSETFROM:+0200"
"RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU"
**"DTSTART:19961027T030000"**
"TZNAME:GMT+01:00"
"TZOFFSETTO:+0100"
"END:STANDARD"
"END:VTIMEZONE"
"BEGIN:VTIMEZONE"
"TZID:Asia/Tokyo"
"BEGIN:DAYLIGHT"
"TZOFFSETFROM:+0900"
"RRULE:FREQ=YEARLY;UNTIL=19510505T170000Z;BYMONTH=5;BYDAY=1SU"
**"DTSTART:19500507T020000"**
"TZNAME:GMT+9"
"TZOFFSETTO:+1000"
"END:DAYLIGHT"
"BEGIN:STANDARD"
"TZOFFSETFROM:+1000"
**"DTSTART:19510908T020000"**
"TZNAME:GMT+9"
"TZOFFSETTO:+0900"
"END:STANDARD"
"END:VTIMEZONE"
"BEGIN:VTIMEZONE"
"TZID:Europe/Berlin"
"BEGIN:DAYLIGHT"
**"DTSTART:19810329T020000"**
"RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU"
"TZNAME:GMT+2"
"TZOFFSETFROM:+0100"
"TZOFFSETTO:+0200"
"END:DAYLIGHT"
"BEGIN:STANDARD"
**"DTSTART:19961027T030000"**
"RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU"
"TZNAME:GMT+1"
"TZOFFSETFROM:+0200"
"TZOFFSETTO:+0100"
_"END:STANDARD"_
"END:VTIMEZONE"