### PR TITLE
Parse RDATE property

### DIFF
--- a/lib/ex_ical/date_parser.ex
+++ b/lib/ex_ical/date_parser.ex
@@ -111,10 +111,16 @@ defmodule ExIcal.DateParser do
     |> Timex.to_datetime()
   end
 
-  # Date Format: "19690620", Timezone: *
-  def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2) >>, _timezone) do
+  # Date Format: "19690620", Timezone: nil
+  def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2) >>, nil) do
     {to_integers({year, month, day}), {0, 0, 0}}
     |> Timex.to_datetime()
+  end
+
+  # Date Format: "19690620", Timezone: *
+  def parse(<< year :: binary-size(4), month :: binary-size(2), day :: binary-size(2) >>, timezone) do
+    {to_integers({year, month, day}), {0, 0, 0}}
+    |> Timex.to_datetime(timezone)
   end
 
   @spec to_integers({String.t, String.t, String.t}) :: {integer, integer, integer}

--- a/lib/ex_ical/event.ex
+++ b/lib/ex_ical/event.ex
@@ -33,6 +33,10 @@ defmodule ExIcal.Event do
       Defines a rule or repeating pattern for recurring events. Corresponds to
       the iCal `RRULE` property ([4.8.5.4 Recurrence Rule]).
 
+    - `rdate`:
+      Defines a a of date/times for a recurrence set. Corresponds to
+      the iCal `RDATE` property ([4.8.5.3 Recurrence Date/Times).
+
     - `categories`:
       Defines the categories for a calendar component. Corresponds to
       the iCal `CATEGORIES` property ([4.8.1.2 Categories Rule]).
@@ -42,14 +46,15 @@ defmodule ExIcal.Event do
       Corresponds to the iCal `UID` property ([4.8.4.7 Unique Identifier]).
 
   [RFC 2445]: https://www.ietf.org/rfc/rfc2445.txt
-  [4.8.2.4 Date/Time Start]:   http://www.kanzaki.com/docs/ical/dtstart.html
-  [4.8.2.2 Date/Time End]:     http://www.kanzaki.com/docs/ical/dtend.html
-  [4.8.7.2 Date/Time Stamp]:   http://www.kanzaki.com/docs/ical/dtstamp.html
-  [4.8.1.5 Description]:       http://www.kanzaki.com/docs/ical/description.html
-  [4.8.1.12 Summary]:          http://www.kanzaki.com/docs/ical/summary.html
-  [4.8.5.4 Recurrence Rule]:   http://www.kanzaki.com/docs/ical/rrule.html
-  [4.8.1.2 Categories Rule]:   https://www.kanzaki.com/docs/ical/categories.html
-  [4.8.4.7 Unique Identifier]: https://www.kanzaki.com/docs/ical/uid.html
+  [4.8.2.4 Date/Time Start]:       http://www.kanzaki.com/docs/ical/dtstart.html
+  [4.8.2.2 Date/Time End]:         http://www.kanzaki.com/docs/ical/dtend.html
+  [4.8.7.2 Date/Time Stamp]:       http://www.kanzaki.com/docs/ical/dtstamp.html
+  [4.8.1.5 Description]:           http://www.kanzaki.com/docs/ical/description.html
+  [4.8.1.12 Summary]:              http://www.kanzaki.com/docs/ical/summary.html
+  [4.8.5.4 Recurrence Rule]:       http://www.kanzaki.com/docs/ical/rrule.html
+  [4.8.5.3 Recurrence Date/Times]: https://www.kanzaki.com/docs/ical/rdate.html
+  [4.8.1.2 Categories Rule]:       https://www.kanzaki.com/docs/ical/categories.html
+  [4.8.4.7 Unique Identifier]:     https://www.kanzaki.com/docs/ical/uid.html
 
   While this covers many of the commonly-used properties of an iCal `VEVENT`,
   `ExIcal` does not yet have full coverage of all valid properties. More
@@ -62,6 +67,7 @@ defmodule ExIcal.Event do
             description: nil,
             summary: nil,
             rrule: nil,
+            rdate: nil,
             categories: nil,
             uid: nil
 end

--- a/test/ex_ical/date_parser_test.exs
+++ b/test/ex_ical/date_parser_test.exs
@@ -16,7 +16,7 @@ defmodule ExIcal.DateParserTest do
     # Input Datestring |   Parsed Date |  Timezone When Global TZID = ?   |
     #                  |               |           nil |  America/Chicago |
     #------------------+--------------------------------------------------+
-    {        "19690620",     date_match,  utc_tzmatch,      utc_tzmatch,},
+    {        "19690620",     date_match,  utc_tzmatch,  chicago_tzmatch,},
     {       "19690620Z",     date_match,  utc_tzmatch,      utc_tzmatch,},
     { "19690620T201804", datetime_match,  utc_tzmatch,  chicago_tzmatch,},
     {"19690620T201804Z", datetime_match,  utc_tzmatch,      utc_tzmatch,},

--- a/test/ex_ical_date_formats_test.exs
+++ b/test/ex_ical_date_formats_test.exs
@@ -26,7 +26,7 @@ defmodule ExIcal.DateFormatsTest do
     #                               DTSTART input |   Parsed Date |  Timezone with Global TZID = ?   |
     #                                             |               |            nil | America/Chicago |
     #---------------------------------------------+---------------+----------------+-----------------+
-    {                           "DTSTART:19690620",     date_match,    utc_tzmatch,     utc_tzmatch,},
+    {                           "DTSTART:19690620",     date_match,    utc_tzmatch,  chicago_tzmatch},
     {                          "DTSTART:19690620Z",     date_match,    utc_tzmatch,     utc_tzmatch,},
     {                    "DTSTART:19690620T201804", datetime_match,    utc_tzmatch, chicago_tzmatch,},
     {                   "DTSTART:19690620T201804Z", datetime_match,    utc_tzmatch,     utc_tzmatch,},

--- a/test/ex_ical_rdate_test.exs
+++ b/test/ex_ical_rdate_test.exs
@@ -1,0 +1,127 @@
+defmodule ExIcalRDATETest do
+  use ExUnit.Case
+  alias ExIcal.DateParser
+
+  doctest ExIcal
+
+  test "event with RDATE PERIOD" do
+    ical = """
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    DESCRIPTION:Let's go!\n\tWanna see Star Wars?\n\x20It's great
+    DTEND:20221124T104500Z
+    DTSTART:20221124T084500Z
+    RRULE:FREQ=MONTHLY;UNTIL=20161224T083000Z
+    RDATE;TZID=Europe/Berlin;VALUE=PERIOD:20230126T110000/20230126T130000,20230126T150000/20230126T170000,20230126T190000/20230126T210000
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
+    """
+
+    events = ExIcal.parse(ical)
+
+    assert events |> Enum.count() == 1
+
+    event = events |> List.first()
+
+    assert event.description == "Let's go!\nWanna see Star Wars?\nIt's great"
+    assert event.summary == "Film with Amy and Adam"
+    assert event.start == DateParser.parse("20221124T084500Z")
+    assert event.end == DateParser.parse("20221124T104500Z")
+
+    assert event.rdate === [
+      %{
+        start: DateParser.parse("20230126T110000", "Europe/Berlin"),
+        end: DateParser.parse("20230126T130000", "Europe/Berlin")
+      },
+      %{
+        start: DateParser.parse("20230126T150000", "Europe/Berlin"),
+        end: DateParser.parse("20230126T170000", "Europe/Berlin")
+      },
+      %{
+        start: DateParser.parse("20230126T190000", "Europe/Berlin"),
+        end: DateParser.parse("20230126T210000", "Europe/Berlin")
+      }
+    ]
+  end
+
+  test "event with RDATE DATE-TIME" do
+    ical = """
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    DESCRIPTION:Let's go!\n\tWanna see Star Wars?\n\x20It's great
+    DTEND:20221124T104500Z
+    DTSTART:20221124T084500Z
+    RRULE:FREQ=MONTHLY;UNTIL=20161224T083000Z
+    RDATE;TZID=Europe/Berlin;VALUE=DATE-TIME:20230126T110000,20230126T150000,20230126T190000
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
+    """
+
+    events = ExIcal.parse(ical)
+
+    assert events |> Enum.count() == 1
+
+    event = events |> List.first()
+
+    assert event.description == "Let's go!\nWanna see Star Wars?\nIt's great"
+    assert event.summary == "Film with Amy and Adam"
+    assert event.start == DateParser.parse("20221124T084500Z")
+    assert event.end == DateParser.parse("20221124T104500Z")
+
+    assert event.rdate === [
+      %{
+        start: DateParser.parse("20230126T110000", "Europe/Berlin"),
+        end: nil
+      },
+      %{
+        start: DateParser.parse("20230126T150000", "Europe/Berlin"),
+        end: nil
+      },
+      %{
+        start: DateParser.parse("20230126T190000", "Europe/Berlin"),
+        end: nil
+      }
+    ]
+  end
+
+  test "event with RDATE DATE" do
+    ical = """
+    BEGIN:VCALENDAR
+    CALSCALE:GREGORIAN
+    VERSION:2.0
+    BEGIN:VEVENT
+    DESCRIPTION:Let's go!\n\tWanna see Star Wars?\n\x20It's great
+    DTEND:20221124T104500Z
+    DTSTART:20221124T084500Z
+    RRULE:FREQ=MONTHLY;UNTIL=20161224T083000Z
+    RDATE:20230126
+    SUMMARY:Film with Amy and Adam
+    END:VEVENT
+    END:VCALENDAR
+    """
+
+    events = ExIcal.parse(ical)
+
+    assert events |> Enum.count() == 1
+
+    event = events |> List.first()
+
+    assert event.description == "Let's go!\nWanna see Star Wars?\nIt's great"
+    assert event.summary == "Film with Amy and Adam"
+    assert event.start == DateParser.parse("20221124T084500Z")
+    assert event.end == DateParser.parse("20221124T104500Z")
+
+    assert event.rdate === [
+      %{
+        start: DateParser.parse("20230126"),
+        end: nil
+      }
+    ]
+  end
+end


### PR DESCRIPTION
Parse `RDATE` property

For more information, read https://www.kanzaki.com/docs/ical/rdate.html

```
The property is defined by the following notation:

  rdate      = "RDATE" rdtparam ":" rdtval *("," rdtval) CRLF

  rdtparam   = *(

             ; the following are optional,
             ; but MUST NOT occur more than once

             (";" "VALUE" "=" ("DATE-TIME" / "DATE" / "PERIOD")) /
             (";" tzidparam) /

             ; the following is optional,
             ; and MAY occur more than once

             (";" xparam)

             )

  rdtval     = date-time / date / period
  ;Value MUST match value type
``` 